### PR TITLE
Fix rbenv detection

### DIFF
--- a/external-tools/rbenv.zsh
+++ b/external-tools/rbenv.zsh
@@ -55,7 +55,7 @@ else
 fi
 
 for rbenvdir in "${rbenvdirs[@]}"; do
-  if [ -d ${rbenvdir}/bin -a ${FOUND_RBENV} -eq 0 ]; then
+  if [ -d ${rbenvdir} -a ${FOUND_RBENV} -eq 0 ]; then
     FOUND_RBENV=1
     if [[ ${RBENV_ROOT} = "" ]]; then
       export RBENV_ROOT=${rbenvdir}


### PR DESCRIPTION
The `bin` directory isn't initially available, so detection should be without `bin` folder.
